### PR TITLE
use pixz instead of pxz

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ to use the Docker build described below.
 To install the required dependencies for pi-gen you should run:
 
 ```bash
-apt-get install coreutils quilt parted realpath qemu-user-static debootstrap zerofree pxz zip \
+apt-get install coreutils quilt parted realpath qemu-user-static debootstrap zerofree pixz zip \
 dosfstools bsdtar libcap2-bin grep rsync xz-utils file git curl
 ```
 

--- a/depends
+++ b/depends
@@ -4,7 +4,8 @@ realpath:coreutils
 qemu-arm-static:qemu-user-static
 debootstrap
 zerofree
-pxz zip
+pixz
+zip
 mkdosfs:dosfstools
 capsh:libcap2-bin
 bsdtar

--- a/export-noobs/prerun.sh
+++ b/export-noobs/prerun.sh
@@ -33,8 +33,8 @@ mount "$BOOT_DEV" "${STAGE_WORK_DIR}/rootfs/boot"
 
 ln -sv "/lib/systemd/system/apply_noobs_os_config.service" "$ROOTFS_DIR/etc/systemd/system/multi-user.target.wants/apply_noobs_os_config.service"
 
-bsdtar --numeric-owner --format gnutar --use-compress-program pxz -C "${STAGE_WORK_DIR}/rootfs/boot" -cpf "${NOOBS_DIR}/boot.tar.xz" .
+bsdtar --numeric-owner --format gnutar --use-compress-program pixz -C "${STAGE_WORK_DIR}/rootfs/boot" -cpf "${NOOBS_DIR}/boot.tar.xz" .
 umount "${STAGE_WORK_DIR}/rootfs/boot"
-bsdtar --numeric-owner --format gnutar --use-compress-program pxz -C "${STAGE_WORK_DIR}/rootfs" --one-file-system -cpf "${NOOBS_DIR}/root.tar.xz" .
+bsdtar --numeric-owner --format gnutar --use-compress-program pixz -C "${STAGE_WORK_DIR}/rootfs" --one-file-system -cpf "${NOOBS_DIR}/root.tar.xz" .
 
 unmount_image "${IMG_FILE}"


### PR DESCRIPTION
pixz is available in all Debian suites from stable to testing to
unstable, while pxz has been removed already in Debian and remains
only in stable. pixz is also parallel.